### PR TITLE
A fix to extend the range of URL in the generateXlsx function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,33 @@
 import { downloadBlob } from './helpers'
 import replace from './main'
 
-export const generateXlsx = async (template, data) => {
-  if (!template || !data) throw Error('No template or data provided')
-  if (typeof template.match === 'string' && template.match(/^https:/)) {
-    const response = await fetch(template)
-    template = response.arrayBuffer()
-  }
-  return await replace(template, data)
+/**
+ * Generates an XLSX file by replacing data in a template file.
+ * @param {string} templateURL - The URL of the template XLSX file.
+ * @param {Object} data - The data object containing values to replace in the template.
+ * @returns {Promise<Blob>} A promise that resolves with the Blob of the generated XLSX file.
+ * @throws {Error} Throws an error if either the templateURL or data is not provided, or if unable to fetch the template file.
+ */
+export async function generateXlsx(templateURL, data) {
+  if (!templateURL || !data) throw new Error('No templateURL or data provided')
+  return await fetch(templateURL)
+    .then(response => {
+      if (response.ok) return response.arrayBuffer()
+      throw new Error(`Unable to fetch the template at: ${templateURL}`)
+    })
+    .then(template => replace(template, data))
+    .catch(e => console.error(e))
 }
 
-export const downloadXlsx = async (template, data, fileName, mimeType) => {
-  if (!fileName) fileName = new Date().toISOString().substring(0, 10) + ' - Report.xlsx'
-  downloadBlob(await generateXlsx(template, data), fileName, mimeType)
+/**
+ * Downloads an XLSX file by replacing data in a template file and initiates the download in the browser.
+ * @param {string} templateURL - The URL of the template XLSX file.
+ * @param {Object} data - The data object containing values to replace in the template.
+ * @param {string} [fileName] - The name of the file to be downloaded. If not provided, a default name based on the current date will be used.
+ * @returns {Promise<void>} A promise that resolves once the download is initiated.
+ */
+export async function downloadXlsx(templateURL, data, fileName) {
+  fileName = fileName || `${new Date().toISOString().substring(0, 10)} - Report.xlsx`
+  const mimeType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  downloadBlob(await generateXlsx(templateURL, data), fileName, mimeType)
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -142,7 +142,7 @@ const replace = async (template, data) => {
           const value = c
           const cellType = 'f'
           newCells[newIndex] = Object.assign({}, { value, cellType }, { template: c })
-          return false          
+          return false
         }
         // Check if the cell contains string
         let isString = c.getAttribute('t')
@@ -231,8 +231,8 @@ const replace = async (template, data) => {
   sst.replaceWith(newSst)
   const newData = serializer.serializeToString(xml).replace(/ ?xmlns="http:\/\/www\.w3\.org\/1999\/xhtml"/g, '')
   // Save new shared strings
-  await new_zip.file('xl/sharedStrings.xml', newData)
-  return await new_zip.generateAsync({ type: 'blob' })
+  new_zip.file('xl/sharedStrings.xml', newData)
+  return new_zip.generateAsync({ type: 'blob' })
 }
 
 export default replace


### PR DESCRIPTION
### Motivation
In order to use this package in webExtension, http website, or use different kind of request in the fetch() i submit this pull request. 
This should remain fully backward compatible with previous implementation.
### Changes
1. Removing the type string check and the https match on the url in `function generateXlsx()`
2. Handling fetch error with response.ok.
3. Using .then() to chain the promises.
4. Adding the JSdoc for the function in index.js.

It also removes a couple of `await` that were redundant.
